### PR TITLE
Fixed some bugs on exporting models

### DIFF
--- a/espnet_onnx/export/asr/export_asr.py
+++ b/espnet_onnx/export/asr/export_asr.py
@@ -73,7 +73,7 @@ class ModelExport:
         # export lm
         if 'lm' in model.beam_search.full_scorers.keys():
             lm_model = LanguageModel(model.beam_search.full_scorers['lm'])
-            self._export_lm(lm_model, enc_out_size, export_dir)
+            self._export_lm(lm_model, export_dir)
             model_config.update(lm=lm_model.get_model_config(export_dir))
         else:
             model_config.update(lm=dict(use_lm=False))
@@ -150,12 +150,12 @@ class ModelExport:
             dynamic_axes=ctc_model.get_dynamic_axes()
         )
 
-    def _export_lm(self, lm_model, enc_size, path):
+    def _export_lm(self, lm_model, path):
         file_name = os.path.join(path, 'lm.onnx')
         # export encoder
         torch.onnx.export(
             lm_model,
-            lm_model.get_dummy_inputs(enc_size),
+            lm_model.get_dummy_inputs(),
             file_name,
             verbose=True,
             opset_version=11,

--- a/espnet_onnx/export/asr/get_config.py
+++ b/espnet_onnx/export/asr/get_config.py
@@ -31,13 +31,14 @@ def get_token_config(model):
     }
 
 
-def get_tokenizer_config(model):
+def get_tokenizer_config(model, path):
     if model is None:
         return {}
     elif isinstance(model, SentencepiecesTokenizer):
+        model_name = os.path.basename(model.model)
         return {
             "token_type": "bpe",
-            "bpemodel": model.model
+            "bpemodel": str(path.parent / model_name)
         }
     elif isinstance(model, WordTokenizer):
         return {

--- a/espnet_onnx/export/asr/models/language_models/lm.py
+++ b/espnet_onnx/export/asr/models/language_models/lm.py
@@ -103,7 +103,7 @@ class SequentialRNNLM(nn.Module, AbsModel):
                 hidden1
             )
     
-    def get_dummy_inputs(self, enc_size):
+    def get_dummy_inputs(self):
         tgt = torch.LongTensor([0, 1]).unsqueeze(0)
         hidden = torch.randn(self.nlayers, 1, self.nhid)
         if self.rnn_type == 'LSTM':
@@ -187,13 +187,13 @@ class TransformerLM(nn.Module):
         h = self.decoder(xs[:, -1])
         return h, new_cache
 
-    def get_dummy_inputs(self, enc_size):
-        tgt = torch.LongTensor([0, sos_token]).unsqueeze(0)
+    def get_dummy_inputs(self):
+        tgt = torch.LongTensor([0, 1]).unsqueeze(0)
         ys_mask = tgt != 0
         m = torch.from_numpy(subsequent_mask(ys_mask.shape[-1])[None, :])
         mask = ys_mask[None, :] * m
         cache = [
-            torch.zeros((1, 1, enc_size))
+            torch.zeros((1, 1, self.encoder.encoders[0].size))
             for _ in range(len(self.encoder.encoders))
         ]
         return (tgt, mask, cache)


### PR DESCRIPTION
Fixed some problems with exporting the following models

Bugs:
- TransformerLM
  `sos_token` was used in `get_dummy_inputs()`, but it is not defined.
- bpemodel
  A model file of `bpemodel` is not copied to the new cache directory so that someone who does not install `espnet_model_zoo` cannot use `bpe` as a tokenizer.