### PR TITLE
small bugfix

### DIFF
--- a/espnet_onnx/export/asr/export_asr.py
+++ b/espnet_onnx/export/asr/export_asr.py
@@ -117,6 +117,12 @@ class ASRModelExport:
                     model_idx = int(m.split('_')[1])
                     model_config['decoder']['predecoder'][model_idx].update(
                         quantized_model_path=qt_config[m])
+                elif 'encoder' in m:
+                    model_config['encoder'].update(quantized_model_path=qt_config[m])
+                elif 'decoder' in m:
+                    model_config['decoder'].update(quantized_model_path=qt_config[m])
+                elif 'lm' in m:
+                    model_config['lm'].update(quantized_model_path=qt_config[m])
                 else:
                     model_config[m].update(quantized_model_path=qt_config[m])
 

--- a/espnet_onnx/export/tts/models/tts_models/fastspeech2.py
+++ b/espnet_onnx/export/tts/models/tts_models/fastspeech2.py
@@ -15,32 +15,21 @@ from espnet_onnx.utils.abs_model import AbsExportModel
 
 
 class OnnxLengthRegurator(nn.Module):
-    def __init__(self, alpha):
+    def __init__(self, alpha=1.0):
         super().__init__()
         self.alpha = alpha
         # The maximum length of the make_pad_mask is the 
         # maximum value of the duration.
         self.make_pad_mask = MakePadMask(512)
-        self.zero = torch.LongTensor([0])
-    
     def forward(self, x, dur):
         # This class assumes that the batch size of x
         # should be 1.
         if self.alpha != 1.0:
             dur = torch.round(ds.float() * alpha).long()
         dur = dur[0]
-        ma = torch.cumsum(
-            torch.cat((dur, self.zero), dim=0),
-            dim=0
-        )
-        mb = torch.cumsum(
-            torch.cat((self.zero, dur), dim=0),
-            dim=0
-        )
-        _m = self.make_pad_mask(mb)
-        _m[0] = 1
-        mask = ((1 - self.make_pad_mask(ma)) * _m)[:-1]
-        return torch.matmul(x.transpose(1, 2), mask).transpose(1, 2)
+        dm = 1 - self.make_pad_mask(dur)
+        nz = torch.nonzero(dm)[:, 0]
+        return x[:, nz]
 
 
 class OnnxReferenceEncoder(nn.Module):

--- a/espnet_onnx/export/tts/models/tts_models/fastspeech2.py
+++ b/espnet_onnx/export/tts/models/tts_models/fastspeech2.py
@@ -100,7 +100,7 @@ class OnnxFastSpeech2(nn.Module, AbsExportModel):
         if self.langs:
             self.lid_emb = model.lid_emb
         self.encoder.embed = Embedding(self.encoder.embed, max_seq_len=max_seq_len)
-        self.decoder.embed = Embedding(self.decoder.embed, max_seq_len= max_seq_len)
+        self.decoder.embed = Embedding(self.decoder.embed, use_cache=False)
 
     def _source_mask(self, ilens):
         x_masks = 1 - self.make_pad_mask(ilens)

--- a/espnet_onnx/export/tts/models/tts_models/fastspeech2.py
+++ b/espnet_onnx/export/tts/models/tts_models/fastspeech2.py
@@ -65,6 +65,7 @@ class OnnxFastSpeech2(nn.Module, AbsExportModel):
         model,
         max_seq_len: int = 512,
         alpha: float = 1.0,
+        use_cache: bool = True,
         **kwargs
     ):
         super().__init__()
@@ -100,7 +101,7 @@ class OnnxFastSpeech2(nn.Module, AbsExportModel):
         if self.langs:
             self.lid_emb = model.lid_emb
         self.encoder.embed = Embedding(self.encoder.embed, max_seq_len=max_seq_len)
-        self.decoder.embed = Embedding(self.decoder.embed, use_cache=False)
+        self.decoder.embed = Embedding(self.decoder.embed, max_seq_len=max_seq_len, use_cache=use_cache)
 
     def _source_mask(self, ilens):
         x_masks = 1 - self.make_pad_mask(ilens)

--- a/espnet_onnx/export/tts/models/vocoders/hifigan.py
+++ b/espnet_onnx/export/tts/models/vocoders/hifigan.py
@@ -58,6 +58,6 @@ class OnnxHiFiGANVocoder(nn.Module, AbsExportModel):
 
     def get_model_config(self, path):
         return {
-            'vocoder_type': 'HiFiGANVocoder',
+            'vocoder_type': 'OnnxVocoder',
             'model_path': str(path / f'{self.model_name}.onnx')
         }

--- a/espnet_onnx/export/tts/models/vocoders/melgan.py
+++ b/espnet_onnx/export/tts/models/vocoders/melgan.py
@@ -44,6 +44,6 @@ class OnnxMelGANVocoder(nn.Module, AbsExportModel):
 
     def get_model_config(self, path):
         return {
-            'vocoder_type': 'MelGANVocoder',
+            'vocoder_type': 'OnnxVocoder',
             'model_path': str(path / f'{self.model_name}.onnx')
         }

--- a/espnet_onnx/export/tts/models/vocoders/parallel_wavegan.py
+++ b/espnet_onnx/export/tts/models/vocoders/parallel_wavegan.py
@@ -68,6 +68,6 @@ class OnnxPWGVocoder(nn.Module, AbsExportModel):
 
     def get_model_config(self, path):
         return {
-            'vocoder_type': 'OnnxPWGVocoder',
+            'vocoder_type': 'OnnxVocoder',
             'model_path': str(path / f'{self.model_name}.onnx')
         }

--- a/espnet_onnx/export/tts/models/vocoders/style_melgan.py
+++ b/espnet_onnx/export/tts/models/vocoders/style_melgan.py
@@ -69,6 +69,6 @@ class OnnxStyleMelGANVocoder(nn.Module, AbsExportModel):
 
     def get_model_config(self, path):
         return {
-            'vocoder_type': 'StyleMelGANVocoder',
+            'vocoder_type': 'OnnxVocoder',
             'model_path': str(path / f'{self.model_name}.onnx')
         }


### PR DESCRIPTION
## Bugfix for TTS
This is a bugfix for #24
When using the VITS or FastSpeech2 model, you cannot infer sequences longer than 100-200.
Details are described in the issue.