### PR TITLE
Bugfix in exporting model with xvector

### DIFF
--- a/espnet_onnx/export/layers/attention.py
+++ b/espnet_onnx/export/layers/attention.py
@@ -3,6 +3,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
+from espnet_onnx.utils.torch_function import normalize
 from espnet.nets.pytorch_backend.rnn.attentions import (
     NoAtt,
     AttDot,
@@ -492,7 +493,7 @@ class OnnxAttForward(torch.nn.Module):
         att_prev_shift = F.pad(att_prev, (1, 0))[:, :-1]
         w = (att_prev + att_prev_shift) * w
         # NOTE: clamp is needed to avoid nan gradient
-        w = F.normalize(torch.clamp(w, 1e-6), p=1, dim=1)
+        w = normalize(torch.clamp(w, 1e-6), p=1, dim=1)
 
         # weighted sum over flames
         # utt x hdim

--- a/espnet_onnx/tts/model/tts_models/fast_speech2.py
+++ b/espnet_onnx/tts/model/tts_models/fast_speech2.py
@@ -44,6 +44,7 @@ class FastSpeech2:
         self.use_sids = 'sids' in self.input_names
         self.use_lids = 'lids' in self.input_names
         self.use_feats = 'feats' in self.input_names
+        self.use_spk_embed_dim = 'spembs' in self.input_names
 
     def __call__(
         self,

--- a/espnet_onnx/tts/model/tts_models/jets.py
+++ b/espnet_onnx/tts/model/tts_models/jets.py
@@ -43,6 +43,7 @@ class JETS:
         self.use_sids = 'sids' in self.input_names
         self.use_lids = 'lids' in self.input_names
         self.use_feats = 'feats' in self.input_names
+        self.use_spk_embed_dim = 'spembs' in self.input_names
 
     def __call__(
         self,

--- a/espnet_onnx/tts/model/tts_models/tacotron2.py
+++ b/espnet_onnx/tts/model/tts_models/tacotron2.py
@@ -41,6 +41,7 @@ class Tacotron2:
         self.use_sids = 'sids' in self.input_names
         self.use_lids = 'lids' in self.input_names
         self.use_feats = 'feats' in self.input_names
+        self.use_spk_embed_dim = 'spembs' in self.input_names
         self.dlayers = self.config.decoder.dlayers
         self.dunits = self.config.decoder.dunits
         self.threshold = self.config.decoder.threshold

--- a/espnet_onnx/tts/model/tts_models/vits.py
+++ b/espnet_onnx/tts/model/tts_models/vits.py
@@ -41,6 +41,7 @@ class VITS:
 
         self.input_names = [d.name for d in self.model.get_inputs()]
         self.use_sids = 'sids' in self.input_names
+        self.use_spk_embed_dim = 'spembs' in self.input_names
         self.use_lids = 'lids' in self.input_names
         self.use_feats = 'feats' in self.input_names
 

--- a/espnet_onnx/tts/tts_model.py
+++ b/espnet_onnx/tts/tts_model.py
@@ -67,9 +67,14 @@ class Text2Speech(AbsTTSModel):
         options = dict()
         if self.tts_model.use_sids:
             if sids is None or spembs is None:
-                raise RuntimeError("'sids' or 'spembs' is missing.")
+                raise RuntimeError("'sids' is missing.")
             else:
-                options.update(sids=sids, spembs=spembs)
+                options.update(sids=sids)
+        if self.tts_model.use_spk_embed_dim:
+            if spembs is None:
+                raise RuntimeError("'spembs' is missing.")
+            else:
+                options.update(spembs=spembs)
         if self.tts_model.use_lids:
             if lids is None:
                 raise RuntimeError("Missing required argument: 'lids'")

--- a/espnet_onnx/utils/torch_function.py
+++ b/espnet_onnx/utils/torch_function.py
@@ -1,3 +1,4 @@
+from typing import Optional
 
 import torch
 import torch.nn as nn
@@ -42,3 +43,12 @@ class MakePadMask(nn.Module):
             return mask.transpose(1, 2)
         else:
             return mask
+
+
+def normalize(input: torch.Tensor, p: float = 2.0, dim: int = 1, out: Optional[torch.Tensor] = None) -> torch.Tensor:
+    if out is None:
+        denom = input.norm(p, dim, keepdim=True).expand_as(input)
+        return input / denom
+    else:
+        denom = input.norm(p, dim, keepdim=True).expand_as(input)
+        return torch.div(input, denom, out=out)


### PR DESCRIPTION
- bugfix of #37 

- Implemented `normalize()` and use it in TTS export model instead of `torch.nn.functional.normalize`.  
- Fixed logic in get_input_name